### PR TITLE
Adding Floyd Warshall Algorithm in Python

### DIFF
--- a/floyd-warsh.py
+++ b/floyd-warsh.py
@@ -1,0 +1,30 @@
+# Number of vertices
+nV = 4
+INF = 999
+
+# Algorithm 
+def floyd(G):
+    dist = list(map(lambda p: list(map(lambda q: q, p)), G))
+
+    # Adding vertices individually
+    for r in range(nV):
+        for p in range(nV):
+            for q in range(nV):
+                dist[p][q] = min(dist[p][q], dist[p][r] + dist[r][q])
+    sol(dist)
+
+# Printing the output
+def sol(dist):
+    for p in range(nV):
+        for q in range(nV):
+            if(dist[p][q] == INF):
+                print("INF", end=" ")
+            else:
+                print(dist[p][q], end="  ")
+        print(" ")
+
+G = [[0, 5, INF, INF],
+         [50, 0, 15, 5],
+         [30, INF, 0, 15],
+         [15, INF, 5, 0]]
+floyd(G)


### PR DESCRIPTION
Just like Dijkstra’s algorithm, the Floyd Warshall algorithm is used to find the shortest path between all vertices in the weighted graph. This algorithm works with both directed and undirected graphs but it does not work along with the graph with negative cycles. Therefore, if the distance from the vertex v from itself is negative then we can assume that the graph has the presence of a negative cycle. This algorithm follows the dynamic programming approach as its working pattern. Here the algorithm doesn’t construct the path itself but it can reconstruct the path with a simple modification. Floyd Warshall algorithm is also known as Roy Warshall algorithm or Roy-Floyd algorithm. Let us study the working of the Floyd Warshall algorithm.